### PR TITLE
Fix error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
+var util = require("util");
 module.exports = {
 	require: function(key, defaultValue) {
 		if(process.env[key] === undefined) {
 			if(defaultValue === undefined) {
-				throw new Error('The environment variable "%s" is not defined, and no default value is available', key);
+				throw new Error(util.format('The environment variable "%s" is not defined, and no default value is available', key));
 			}
 			else {
 				process.env[key] = defaultValue;


### PR DESCRIPTION
When a required variable does not exist, I have a error stating 'The environment variable "%s" is not defined, and no default value is available'.

This fixes the %s and it's now replaced by the variable name.
